### PR TITLE
Issue 7 - Add MCP tools for Podman volumes GET endpoints

### DIFF
--- a/src/podman_mcp_server/api/volumes_api.py
+++ b/src/podman_mcp_server/api/volumes_api.py
@@ -1,0 +1,18 @@
+"""MCP actions related to Podman volumes."""
+
+from podman_mcp_server.utils.mcp import mcpWrapper
+from podman_mcp_server.utils.request import podman_get
+
+
+class VolumesAPI:
+    @mcpWrapper.tool(description="List Podman volumes.")
+    @staticmethod
+    def podman_list_volumes():
+        """List Podman volumes."""
+        return podman_get("/libpod/volumes/json")
+
+    @mcpWrapper.tool(description="Inspect a Podman volume by name.")
+    @staticmethod
+    def podman_inspect_volume(name: str):
+        """Inspect a Podman volume by name."""
+        return podman_get(f"/libpod/volumes/{name}/json")

--- a/src/podman_mcp_server/server.py
+++ b/src/podman_mcp_server/server.py
@@ -2,7 +2,7 @@
 
 from mcp.server.fastmcp import FastMCP
 from podman_mcp_server.utils.mcp import mcpWrapper
-from podman_mcp_server.api import system_api, containers_api, images_api, networks_api
+from podman_mcp_server.api import system_api, containers_api, images_api, networks_api, volumes_api
 
 
 def main():
@@ -15,6 +15,8 @@ def main():
     containers_api.ContainersAPI()
     images_api.ImagesAPI()
     networks_api.NetworksAPI()
+    volumes_api.VolumesAPI()
+
     # Initialize the mcpWrapper with the MCP instance
     mcpWrapper(mcp)
     mcp.run()


### PR DESCRIPTION
## Summary
Add MCP tools for listing and inspecting Podman volumes.

## Changes
- Added `podman_list_volumes` wrapping `GET /libpod/volumes/json`
- Added `podman_inspect_volume` wrapping `GET /libpod/volumes/{name}/json`
- Integrated `VolumesAPI` into the MCP server so tools register at startup

## Testing
- Created a test volume and confirmed list/inspect return expected JSON via the MCP server

Fixes Issue #7.
