### PR TITLE
Issue 11 – Add MCP tools for Podman manifests GET endpoints

### DIFF
--- a/src/podman_mcp_server/api/manifests_api.py
+++ b/src/podman_mcp_server/api/manifests_api.py
@@ -1,0 +1,47 @@
+"""MCP actions related to Podman manifests."""
+
+from podman_mcp_server.utils.mcp import mcpWrapper
+from podman_mcp_server.utils.request import podman_get
+
+
+class ManifestsAPI:
+    @mcpWrapper.tool(description="List local Podman manifest lists.")
+    @staticmethod
+    def podman_list_manifests():
+        """List local Podman manifest lists."""
+        # Podman does not expose a GET endpoint to list manifests directly.
+        # Use image names as candidates, then keep only the names that succeed
+        # when inspected through /libpod/manifests/{name}/json.
+        images = podman_get("/libpod/images/json")
+        if not isinstance(images, list):
+            return images
+
+        manifests = []
+        seen = set()
+
+        for img in images:
+            names = img.get("Names") or []
+            for name in names:
+                if name in seen:
+                    continue
+
+                try:
+                    manifest = podman_get(f"/libpod/manifests/{name}/json")
+                    manifests.append(
+                        {
+                            "name": name,
+                            "manifest": manifest,
+                        }
+                    )
+                    seen.add(name)
+                    break
+                except Exception:
+                    continue
+
+        return manifests
+
+    @mcpWrapper.tool(description="Inspect a Podman manifest by name.")
+    @staticmethod
+    def podman_inspect_manifest(name: str):
+        """Inspect a Podman manifest by name."""
+        return podman_get(f"/libpod/manifests/{name}/json")

--- a/src/podman_mcp_server/server.py
+++ b/src/podman_mcp_server/server.py
@@ -2,7 +2,7 @@
 
 from mcp.server.fastmcp import FastMCP
 from podman_mcp_server.utils.mcp import mcpWrapper
-from podman_mcp_server.api import system_api, containers_api, images_api, networks_api, volumes_api
+from podman_mcp_server.api import system_api, containers_api, images_api, networks_api, volumes_api, manifests_api
 
 
 def main():
@@ -16,6 +16,7 @@ def main():
     images_api.ImagesAPI()
     networks_api.NetworksAPI()
     volumes_api.VolumesAPI()
+    manifests_api.ManifestsAPI()
 
     # Initialize the mcpWrapper with the MCP instance
     mcpWrapper(mcp)


### PR DESCRIPTION
## Summary
Add MCP tools for listing and inspecting Podman manifests.

## Changes
- Added podman_list_manifests wrapping manifest discovery logic
- Added podman_inspect_manifest wrapping GET /libpod/manifests/{name}/json
- Integrated ManifestsAPI into the MCP server so tools register at startup

## Testing
- Created test manifests and confirmed list/inspect return expected JSON via the MCP server.

Fixes Issue #11.
