### PR TITLE
Implement /libpod/events MCP tool

### DIFF
--- a/src/podman_mcp_server/api/events_api.py
+++ b/src/podman_mcp_server/api/events_api.py
@@ -1,0 +1,12 @@
+"""MCP actions related to Podman events."""
+
+from podman_mcp_server.utils.mcp import mcpWrapper
+from podman_mcp_server.utils.request import podman_get
+
+
+class EventsAPI:
+    @mcpWrapper.tool()
+    @staticmethod
+    def podman_get_events():
+        """Get Podman events."""
+        return podman_get("/libpod/events?since=1m")

--- a/src/podman_mcp_server/api/events_api.py
+++ b/src/podman_mcp_server/api/events_api.py
@@ -1,12 +1,34 @@
 """MCP actions related to Podman events."""
 
+import json
+import time
+import requests_unixsocket
+
 from podman_mcp_server.utils.mcp import mcpWrapper
-from podman_mcp_server.utils.request import podman_get
 
 
 class EventsAPI:
-    @mcpWrapper.tool()
     @staticmethod
-    def podman_get_events():
-        """Get Podman events."""
-        return podman_get("/libpod/events?since=1m")
+    @mcpWrapper.tool()
+    def podman_get_events(since: str = "1m"):
+        """
+        Get Podman events.
+
+        Args:
+            since (str): Time range for events, e.g. "10s", "5m", "1h".
+        """
+
+        now = int(time.time())
+
+        uri = "http+unix://%2Frun%2Fuser%2F1000%2Fpodman%2Fpodman.sock"
+        endpoint = f"/v6.0.0/libpod/events?since={since}&until={now}"
+
+        session = requests_unixsocket.Session()
+        response = session.get(f"{uri}{endpoint}")
+        response.raise_for_status()
+
+        # events are newline-separated JSON, so parse each line
+        events = [json.loads(line) for line in response.text.splitlines() if line.strip()]
+
+        return events
+        

--- a/src/podman_mcp_server/api/volumes_api.py
+++ b/src/podman_mcp_server/api/volumes_api.py
@@ -5,13 +5,13 @@ from podman_mcp_server.utils.request import podman_get
 
 
 class VolumesAPI:
-    @mcpWrapper.tool(description="List Podman volumes.")
+    @mcpWrapper.tool()
     @staticmethod
     def podman_list_volumes():
         """List Podman volumes."""
         return podman_get("/libpod/volumes/json")
 
-    @mcpWrapper.tool(description="Inspect a Podman volume by name.")
+    @mcpWrapper.tool()
     @staticmethod
     def podman_inspect_volume(name: str):
         """Inspect a Podman volume by name."""

--- a/src/podman_mcp_server/server.py
+++ b/src/podman_mcp_server/server.py
@@ -2,7 +2,7 @@
 
 from mcp.server.fastmcp import FastMCP
 from podman_mcp_server.utils.mcp import mcpWrapper
-from podman_mcp_server.api import system_api, containers_api, images_api, networks_api, volumes_api, manifests_api
+from podman_mcp_server.api import system_api, containers_api, images_api, networks_api, volumes_api, manifests_api, events_api
 
 
 def main():
@@ -17,7 +17,8 @@ def main():
     networks_api.NetworksAPI()
     volumes_api.VolumesAPI()
     manifests_api.ManifestsAPI()
-
+    events_api.EventsAPI()
+    
     # Initialize the mcpWrapper with the MCP instance
     mcpWrapper(mcp)
     mcp.run()


### PR DESCRIPTION
Summary
Add an MCP tool for the /libpod/events endpoint.

Changes
- Added EventsAPI with a podman_get_events tool
- Registered EventsAPI in the MCP server

Testing
- Started the MCP server locally in a virtual environment
- Tested the events endpoint behavior locally and through Claude