### PR TITLE
Pods GET endpoints and 202 status Hotfix

### DIFF
--- a/src/podman_mcp_server/api/pods_api.py
+++ b/src/podman_mcp_server/api/pods_api.py
@@ -1,0 +1,42 @@
+"""MCP actions related to Podman pods."""
+
+from podman_mcp_server.utils.mcp import mcpWrapper
+from podman_mcp_server.utils.request import podman_get
+
+
+class PodsAPI:
+    @mcpWrapper.tool(description="Generate Systemd Units based on a pod or container.")
+    @staticmethod
+    def podman_generate_systemd_units(name: str):
+        """Generate Systemd Unites based on a pod or container."""
+        return podman_get(f"/libpod/generate/{name}/systemd")
+
+    @mcpWrapper.tool(description="Inspect Podman pods by name.")
+    @staticmethod
+    def podman_inspect_pod(name: str):
+        """Inspect a Podman pod by name."""
+        return podman_get(f"/libpod/pods/{name}/json")
+
+    @mcpWrapper.tool(description="List Podman pods.")
+    @staticmethod
+    def podman_list_pods():
+        """List Podman pods."""
+        return podman_get("/libpod/pods/json")
+
+    @mcpWrapper.tool(description="List processes running inside a pod.")
+    @staticmethod
+    def list_pod_processes(name: str):
+        """List processes running inside a pod."""
+        return podman_get(f"/libpod/pods/{name}/top")
+
+    @mcpWrapper.tool(description="Check if a pod exists by name.")
+    @staticmethod
+    def podman_check_pod_exists(name: str):
+        """Check if a pod exists by name or ID."""
+        return podman_get(f"/libpod/pods/{name}/exists")
+
+    @mcpWrapper.tool(description="Display statistics for one or more pods.")
+    @staticmethod
+    def podman_check_pod_statistics():
+        """Display a live stream of resource usage statistics for the containers in one or more pods."""
+        return podman_get("/libpod/pods/stats")

--- a/src/podman_mcp_server/server.py
+++ b/src/podman_mcp_server/server.py
@@ -9,6 +9,7 @@ from podman_mcp_server.api import (
     networks_api,
     volumes_api,
     pods_api,
+    manifests_api
 )
 
 

--- a/src/podman_mcp_server/server.py
+++ b/src/podman_mcp_server/server.py
@@ -2,7 +2,14 @@
 
 from mcp.server.fastmcp import FastMCP
 from podman_mcp_server.utils.mcp import mcpWrapper
-from podman_mcp_server.api import system_api, containers_api, images_api, networks_api, volumes_api
+from podman_mcp_server.api import (
+    system_api,
+    containers_api,
+    images_api,
+    networks_api,
+    volumes_api,
+    pods_api,
+)
 
 
 def main():
@@ -16,6 +23,7 @@ def main():
     images_api.ImagesAPI()
     networks_api.NetworksAPI()
     volumes_api.VolumesAPI()
+    pods_api.PodsAPI()
 
     # Initialize the mcpWrapper with the MCP instance
     mcpWrapper(mcp)

--- a/src/podman_mcp_server/utils/request.py
+++ b/src/podman_mcp_server/utils/request.py
@@ -10,9 +10,20 @@ api_version = "v6.0.0"
 session = requests_unixsocket.Session()
 
 
+# TODO: Implement a unified _handle_response() helper to manage 204 No Content
+# responses across podman_get(), podman_post(), and podman_delete().
+# Currently only podman_get() handles 204. See issue with response.json() on empty bodies.
+
+
 def podman_get(endpoint: str) -> str:
     response = session.get(f"{uri}/{api_version}{endpoint}")
     response.raise_for_status()
+
+    if response.status_code == 204:
+        return "Status code 204: No Content. The request was successful but there is no content to return."
+    if response.status_code == 404:
+        return "Status code 404: Not Found. The requested resource could not be found."
+
     return response.json()
 
 


### PR DESCRIPTION
# Summary 
Addition of pods GET endpoints with an additional systemd generator tool with a hot fix in podman_get() to prevent response.json() crashing on empty bodies.

# Changes
* added systemd_units, inspect pods, list pods, list processes running in pods, checking if a pod exists, and displaying pod stats
* implemented a simple statement to return HTTP status code for LLM interpretability

# Testing
Prompted Claude LLM to verify tools is able to hit proper API endpoints. Addresses issue issue #6   

<img width="810" height="474" alt="image" src="https://github.com/user-attachments/assets/6cd800e2-1a67-49a3-87e7-a1da672fb8d4" />
